### PR TITLE
Added support for indentation within embed tag

### DIFF
--- a/indent/twig.vim
+++ b/indent/twig.vim
@@ -45,6 +45,7 @@ call <SID>TwigIndentPush('if')
 call <SID>TwigIndentPush('elseif')
 call <SID>TwigIndentPush('else')
 call <SID>TwigIndentPush('spaceless')
+call <SID>TwigIndentPush('embed')
 
 let s:cpo_save = &cpo
 set cpo-=C


### PR DESCRIPTION
In Twig 1.8 the [embed](http://twig.sensiolabs.org/doc/tags/embed.html) tag was added. This change adds support for indentation for this tag.
